### PR TITLE
Fix check for -P option in core/bin/post-install.sh

### DIFF
--- a/core/bin/post-install.sh
+++ b/core/bin/post-install.sh
@@ -46,7 +46,7 @@ if ! echo -n $SEARCH_HEAD_IP | egrep -q '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0
     exit 1;
 fi
 
-if [ $PING_SEARCH_HEAD ]; then 
+if [ $PING_SEARCH_HEAD -eq 0 ]; then 
     if ! ping -c 1 $SEARCH_HEAD_IP >/dev/null 2>/dev/null; then 
         echo "You must provide the ip of the search head." 
         echo "Note, we partly test this by pinging it. If you know you can't ping the search head right"

--- a/etc/pcapdb.cfg.example
+++ b/etc/pcapdb.cfg.example
@@ -27,6 +27,11 @@ session_secret =
 # Used only for testing, defaults to 443
 # http_port = 8111
 
+# What hostnames are we allowed to serve content *as*?
+# This is a list of hostnames that our web service runs under.
+# Defaults to the local hostname
+# allowed_hosts = 
+
 # The title for the splash page.
 splash_title=Warning
 # Text for the splash page


### PR DESCRIPTION
The existing test appears to assume that `test 1` will evaluate to false: this isn't the case. Any single argument provided to `test` that has a string length >0 will evaluate to true.